### PR TITLE
Version 0.2.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: test install build all
+.PHONY: test install build all image
+
+VERSION=$(shell git describe --abbrev=0 --tags)
+MAJOR_VERSION=$(shell git describe --abbrev=0 --tags | cut -d"." -f1-2)
 
 image:
 	docker build -t komand/python-plugin .
@@ -14,3 +17,7 @@ install:
 test:
 	python setup.py test
 
+tag: image
+	@echo version is $(VERSION)
+	docker tag komand/python-plugin komand/python-plugin:$(VERSION) 
+	docker tag komand/python-plugin:$(VERSION) komand/python-plugin:$(MAJOR_VERSION) 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='0.1',
+      version='0.2.8',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',


### PR DESCRIPTION
Start tracking versions in setup.py.

Adds a helper for developers called the 'tag' task which will correctly tag the release image to match Dockerhub's builds.