### PR TITLE
open_cachefile: IOError: File not open for reading

### DIFF
--- a/komand/helper.py
+++ b/komand/helper.py
@@ -124,7 +124,7 @@ def open_cachefile(cache_file):
     else:
       if not os.path.isdir(os.path.dirname(cache_file)):
         os.makedirs(os.path.dirname(cache_file))
-      f = open(cache_file, 'w')
+      f = open(cache_file, 'w+')
       logging.info('OpenCacheFile: %s created', cache_file)
     return f
   logging.error('OpenCacheFile: %s directory or does not exist', cache_dir)


### PR DESCRIPTION
Upon file creation we need to open the file as read/write.