### PR TITLE
Support a webhook url for the trigger

### DIFF
--- a/komand/action.py
+++ b/komand/action.py
@@ -13,6 +13,7 @@ class Action(object):
         self.input = input 
         self.output = output
         self.connection = None
+        self.debug = False
 
     def run(self, params={}):
         """ Run a action, return output or raise error """

--- a/komand/cli.py
+++ b/komand/cli.py
@@ -34,7 +34,7 @@ class CLI(object):
         if trig:
             conn = self.plugin.connection
             input = trig.input
-            dispatcher = { 'url': 'http://localhost:8000' }
+            dispatcher = { 'url': 'http://localhost:8000', 'webhook_url': '' }
 
             if conn:
                 conn = conn.sample()

--- a/komand/dispatcher.py
+++ b/komand/dispatcher.py
@@ -5,6 +5,12 @@ import requests
 
 class Stdout(object):
     """ stdout dispatcher """
+    def __init__(self, config={}):
+        self.webhook_url = config.get('webhook_url')
+
+        logging.info('Using dispatcher config: %s', config)
+
+
     def write(self, msg):
         message.marshal(msg, sys.stdout)
 
@@ -18,6 +24,7 @@ class Http(object):
             raise ValueError('missing HTTP dispatcher config url')
 
         self.url = config['url']
+        self.webhook_url = config.get('webhook_url')
 
         logging.info('Using dispatcher config: %s', config)
 

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -48,7 +48,7 @@ class Plugin(object):
         msg = message.unmarshal(input)
         runner = self._lookup(msg)
         if self.debug:
-            runner.dispatcher = dispatcher.Stdout()
+            runner.debug = True
 
         runner.run()
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='0.3.1',
+      version='0.3.2',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',


### PR DESCRIPTION
The trigger can use a webhook_url by accessing self.webhook_url  It can be used by the trigger to configure webhooks back into the workflow.  The webhook_url is set by the engine when it starts a trigger.

```
class Webhook(komand.Trigger):

    def __init__(self):
        super(self.__class__, self).__init__(
                name='webhook',
                description='Configure a webhook',
                input=WebhookInput(),
                output=WebhookOutput())

    def run(self, params={}):
        """Run the trigger"""
         # TODO:  do something with self.webhook_url to configure it

         while True:
           # just run forever
            time.sleep(5)


    def test(self):
        """TODO: Test the trigger"""
        return {}

```

When the trigger runs, echo will then be a webhook that looks like this:  

http://localhost:8000/v2/workflows/a252509f-6e9c-e76f-f96d-9d9b7db7f45e/events?api_key=<key>
