### PR TITLE
Adding in custom hooks for plugins to provide encoders/decoders if th…

### DIFF
--- a/komand/action.py
+++ b/komand/action.py
@@ -26,7 +26,12 @@ class Action(object):
 
 class Task(object):
     """Task to run or test an action"""
-    def __init__(self, connection, action, msg, dispatch=dispatcher.Stdout()):
+    def __init__(self, connection, action, msg, dispatch=None, custom_encoder=None, custom_decoder=None):
+        if dispatch is None:
+            dispatch = dispatcher.Stdout({
+                "custom_encoder": custom_encoder,
+                "custom_decoder":custom_decoder
+            })
         self.connection = connection
         self.action = action
         self.msg = msg

--- a/komand/dispatcher.py
+++ b/komand/dispatcher.py
@@ -7,9 +7,11 @@ class Stdout(object):
     """ stdout dispatcher """
     def __init__(self, config={}):
         self.webhook_url = config.get('webhook_url')
+        self.custom_encoder = config.get("custom_encoder")
+        self.custom_decoder = config.get("custom_decoder")
 
     def write(self, msg):
-        message.marshal(msg, sys.stdout)
+        message.marshal(msg, sys.stdout, ce=self.custom_encoder)
 
 class Http(object):
     """ HTTP dispatcher """
@@ -22,6 +24,8 @@ class Http(object):
 
         self.url = config['url']
         self.webhook_url = config.get('webhook_url')
+        self.custom_encoder = config.get("custom_encoder")
+        self.custom_decoder = config.get("custom_decoder")
 
         logging.info('Using dispatcher config: %s', config)
 

--- a/komand/message.py
+++ b/komand/message.py
@@ -89,19 +89,29 @@ validators = {
     ACTION_START:  validateActionStart,
 }
 
-def marshal(msg, fd=sys.stdout):
+def marshal(msg, fd=sys.stdout, ce=None):
     """ Marshal a message to fd"""
-    json.dump(msg, fd)
+    if ce is None:
+        json.dump(msg, fd)
+    else:
+        json.dump(msg, fd, cls=ce)
     fd.flush()
 
-def marshal_string(msg):
+def marshal_string(msg, ce=None):
     """ Marshal a message to a string"""
-    return json.dumps(msg)
+    if ce is None:
+        return json.dumps(msg)
+    else:
+        return json.dumps(msg, cls=ce)
 
-def unmarshal(fd=sys.stdin):
+def unmarshal(fd=sys.stdin, cd=None):
     """Unmarshals a message"""
     try:
-        msg = json.load(fd)
+        msg = None
+        if cd is None:
+            msg = json.load(fd)
+        else:
+            msg = json.load(fd, cls=cd)
     except Exception as e:
         raise Exception("Invalid message json: %s" % e)
 

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -13,7 +13,7 @@ except ImportError:
 class Plugin(object):
     """An Komand Plugin."""
 
-    def __init__(self, name='', vendor='', description='', version='', connection=None):
+    def __init__(self, name='', vendor='', description='', version='', connection=None, custom_encoder=None, custom_decoder=None):
         self.name = name
         self.vendor = vendor
         self.description = description
@@ -22,8 +22,8 @@ class Plugin(object):
         self.triggers = {}
         self.actions = {}
         self.debug = False
-        self.custom_decoder = None
-        self.custom_encoder = None
+        self.custom_decoder = custom_decoder
+        self.custom_encoder = custom_encoder
 
     def _lookup(self, msg):
         if msg['type'] == message.TRIGGER_START:

--- a/komand/plugin.py
+++ b/komand/plugin.py
@@ -14,28 +14,34 @@ class Plugin(object):
     """An Komand Plugin."""
 
     def __init__(self, name='', vendor='', description='', version='', connection=None):
-        self.name = name 
-        self.vendor = vendor 
-        self.description = description 
-        self.version = version 
+        self.name = name
+        self.vendor = vendor
+        self.description = description
+        self.version = version
         self.connection = connection
         self.triggers = {}
         self.actions = {}
         self.debug = False
+        self.custom_decoder = None
+        self.custom_encoder = None
 
     def _lookup(self, msg):
         if msg['type'] == message.TRIGGER_START:
             trig = self._trigger(msg['body'])
             return trigger.Task(
-                    connection=self.connection, 
-                    trigger=trig, 
-                    msg=msg['body']) 
+                connection=self.connection,
+                trigger=trig,
+                msg=msg['body'],
+                custom_encoder=self.custom_encoder,
+                custom_decoder=self.custom_decoder)
         elif msg['type'] == message.ACTION_START:
             act = self._action(msg['body'])
             return action.Task(
-                    connection=self.connection, 
-                    action=act, 
-                    msg=msg['body']) 
+                connection=self.connection,
+                action=act,
+                msg=msg['body'],
+                custom_encoder=self.custom_encoder,
+                custom_decoder=self.custom_decoder)
         else:
             raise Exception("Invalid message type:" + msg.Type)
 
@@ -45,7 +51,7 @@ class Plugin(object):
         if msg:
             input = StringIO(msg)
 
-        msg = message.unmarshal(input)
+        msg = message.unmarshal(input, cd=self.custom_decoder)
         runner = self._lookup(msg)
         if self.debug:
             runner.debug = True
@@ -58,7 +64,7 @@ class Plugin(object):
         if msg:
             input = StringIO(msg)
 
-        msg = message.unmarshal(input)
+        msg = message.unmarshal(input, cd=self.custom_decoder)
 
         if not msg:
             msg = message.unmarshal(sys.stdin)

--- a/komand/trigger.py
+++ b/komand/trigger.py
@@ -51,10 +51,10 @@ class Task(object):
 
     def test(self):
         """ Run test """
-        dispatch = dispatcher.Stdout(self.msg.get('dispatcher') or {
-            "custom_encoder": self.custom_encoder,
-            "custom_decoder": self.custom_decoder,
-        })
+        dparams = self.msg.get('dispatcher', {})
+        dparams["custom_encoder"] = self.custom_encoder
+        dparams["custom_decover"] = self.custom_decoder
+        dispatch = dispatcher.Stdout(dparams)
 
         try:
             self._setup(False)
@@ -96,18 +96,18 @@ class Task(object):
 
     def _setup(self, validate=True):
         trigger_msg = self.msg
-        dparams = {
-            "custom_encoder": self.custom_encoder,
-            "custom_decoder": self.custom_decoder,
-        }
+        tparams = trigger_msg.get('dispatcher', {})
+        tparams["custom_encoder"] = self.custom_encoder
+        tparams["custom_decoder"] = self.custom_decoder
+
         if not trigger_msg:
             raise ValueError('No trigger input to trigger task')
 
         if not self.dispatcher:
             if self.debug:
-                self.dispatcher = dispatcher.Stdout(trigger_msg.get('dispatcher') or dparams)
+                self.dispatcher = dispatcher.Stdout(tparams)
             else:
-                self.dispatcher = dispatcher.Http(trigger_msg.get('dispatcher') or dparams)
+                self.dispatcher = dispatcher.Http(tparams)
 
         self.meta = trigger_msg.get('meta') or {}
 

--- a/sample/foobar/connection.py
+++ b/sample/foobar/connection.py
@@ -17,7 +17,7 @@ class Connection(komand.Connection):
     def __init__(self):
         super(self.__class__, self).__init__(self.schema)
         
-    def connect(self):
+    def connect(self, params={}):
         """ No-op"""
         logging.info("connecting")
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='0.3.2',
+      version='0.3.3',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,10 +5,10 @@ import tests.test_variables
 
 def komand_test_suite():
     testmodules = [
-            test_message,
-            test_action,
-            test_variables,
-            ]
+        test_message,
+        test_action,
+        test_variables,
+        ]
 
     suite = unittest.TestSuite()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,12 +2,14 @@ import unittest
 import tests.test_message
 import tests.test_action
 import tests.test_variables
+import tests.test_custom_encoder
 
 def komand_test_suite():
     testmodules = [
         test_message,
         test_action,
         test_variables,
+        test_custom_encoder,
         ]
 
     suite = unittest.TestSuite()

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -19,7 +19,7 @@ class MyConnection(komand.Connection):
     def __init__(self):
         super(self.__class__, self).__init__(self.schema)
     
-    def connect(self):
+    def connect(self, params={}):
         return None
 
 class StupidActionInput(komand.Input):

--- a/tests/test_custom_encoder.py
+++ b/tests/test_custom_encoder.py
@@ -1,0 +1,93 @@
+import unittest
+from io import StringIO
+import sys, os
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from komand import action 
+import komand
+import json
+import decimal
+
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, o):
+        if isinstance(o, decimal.Decimal):
+            if o % 1 > 0:
+                # This is potentially dangerous - it seems simplejson treats these as strings
+                return float(o)
+            else:
+                return int(o)
+        return super(DecimalEncoder, self).default(o)
+
+class CustomEncoderConnection(komand.Connection):
+    schema = {
+            "type" : "object",
+            "properties" : {
+                "price" : {"type" : "number" },
+                "name" : {"type" : "string"},
+                }
+            }
+
+    def __init__(self):
+        super(self.__class__, self).__init__(self.schema)
+    
+    def connect(self, params={}):
+        return None
+
+class CustomEncoderActionInput(komand.Input):
+    schema = {
+            "type" : "object",
+            "properties" : {
+                "greeting" : {"type" : "string"},
+                }
+            }
+
+    def __init__(self):
+        super(self.__class__, self).__init__(schema=self.schema)
+
+class CustomEncoderActionOutput(komand.Output):
+    schema = {
+            "type" : "object",
+            "required": ["price", "name"],
+            "properties" : {
+                "price" : {"type" : "number" },
+                "name" : {"type" : "string"},
+                }
+            }
+
+    def __init__(self):
+        super(self.__class__, self).__init__(schema=self.schema)
+
+
+class CustomEncoderAction(action.Action):
+    def __init__(self):
+        super(self.__class__, self).__init__(
+                'stupid', 
+                'an action',
+                CustomEncoderActionInput(), 
+                CustomEncoderActionOutput(),
+                )
+
+    def run(self):
+        return { 'price': decimal.Decimal('1100.0'), 'name': 'Jon' }
+
+    def test(self):
+        return { 'price': decimal.Decimal('1.1'), 'name': 'Jon' }
+
+class TestActionRunner(unittest.TestCase):
+
+    def test_custom_encoder_action_succeeds(self):
+        task = action.Task(CustomEncoderConnection(), CustomEncoderAction(), { 
+            'body': { 'action': 'stupid', 
+                'input': {
+                    'greeting': 'hello'
+                    },
+                'meta': { 'action_id': 12345 }, 
+                }
+            }, custom_encoder=DecimalEncoder)
+
+        task.test()
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
…ey need to

ping @jandre @jonschipp 

So, one primary design issue i ran into here is the difference between Action and Trigger Tasks - Action Tasks always defaults to the stdout dispatcher in the method sig, but triggers optionally create the dispatcher in a special way later in the methods.

So ideally I would have just made the dispatchers in plugin.py before calling the ctors on the Tasks, but i didn't want to have responsibility for setting the custom enc/decoders in 2 places. So i pass the custom enc/decoders down and have the Task code set them on the dispatch where it makes sense per-type.

I still need to test all this but wanted to start getting feedback now.