### PR TITLE
Bumping to 0.3.4 to move us beyond the currently incorrect versioning…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='0.3.3',
+      version='0.3.4',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',


### PR DESCRIPTION
… were under

ping @jandre @jonschipp 

We have a tag at 0.3.3 already, which was technically coded internally as a duplicate of 0.3.2.

My latest push bumping the internal tag to 0.3.3 should have been a bump to 0.3.4.

Since I didn't/couldn't push my 0.3.3 tag, that means all we really need to do is bump the patch to 4, then do a proper tag @ 0.3.4 and we're good again.