### PR TITLE
Add Clean Function

### DIFF
--- a/komand/helper.py
+++ b/komand/helper.py
@@ -63,6 +63,29 @@ def clean_list(lst):
       newlist.remove(i)
   return newlist
 
+def clean(object):
+  ''' Returns a new but cleaned JSON object
+  * Recursively iterates through the collection
+  * None type values are removed
+  * Empty string values are removed
+
+  This function is designed so we only return useful data
+  '''
+
+  cleaned = clean_list(object) if isinstance(object, list) else clean_dict(object)
+
+  # The only *real* difference here is how we have to iterate through these different collection types
+  if isinstance(cleaned, list):
+    for key, value in enumerate(cleaned):
+      if isinstance(value, list) or isinstance(value, dict):
+        cleaned[key] = clean(value)
+  elif isinstance(cleaned, dict):
+    for key, value in cleaned.items():
+      if isinstance(value, dict) or isinstance(value, list):
+        cleaned[key] = clean(value)
+
+  return cleaned
+
 def check_hashes(src, checksum):
   '''Return boolean on whether a hash matches a file or string'''
   if type(src) is str:


### PR DESCRIPTION
This PR adds a `clean(object)` function to the helper file. The `clean` function is designed to iterate over the contents of a JSON object, whether it be a dictionary or list, and recursively clean it.

Why? This will save the developer from having to iterate on their own within their plugin. The developer can simply do something like

```
response = requests.get(...)
some_output = komand.helper.clean(response.json())
```

And be on their merry way. Hopefully this helps to speed up development time.

Tested using mockaroo.com to generate test data, and then serializing/unserializing the data and verifying validity with JSONLint.com