### PR TITLE
Helper Library Python 2/3 Compatibility and Helper Library Unit Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 build/
 dist/
 .eggs
-idea./
+.idea/
 .DS_STORE

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 build/
 dist/
 .eggs
+idea./

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -1,16 +1,16 @@
 __all__ = ['message', 'plugin', 'connection', 'trigger', 'action', 'variables', 'cli', 'helper']
 
-import komand.plugin
-
-import komand.action
-import komand.trigger 
-import komand.connection
-import komand.cli
-
-Plugin = komand.plugin.Plugin
-Action = komand.action.Action
-Trigger = komand.trigger.Trigger
-Connection = komand.connection.Connection
-Input = komand.variables.Input
-Output = komand.variables.Output
-CLI = komand.cli.CLI
+# import komand.plugin
+# 
+# import komand.action
+# import komand.trigger 
+# import komand.connection
+# import komand.cli
+# 
+# Plugin = komand.plugin.Plugin
+# Action = komand.action.Action
+# Trigger = komand.trigger.Trigger
+# Connection = komand.connection.Connection
+# Input = komand.variables.Input
+# Output = komand.variables.Output
+# CLI = komand.cli.CLI

--- a/komand/helper.py
+++ b/komand/helper.py
@@ -331,9 +331,10 @@ def check_url_modified(url):
 def get_url_content_disposition(headers):
   '''Return filename as string from content-disposition by supplying requests headers'''
   # Dict is case-insensitive
-  if headers.get('content-disposition'):
-    filename = re.findall("filename=(.+)", headers['content-disposition'])
-    return str(filename[0].strip('"'))
+  for key, value in headers.items():
+    if key.lower() == "content-disposition":
+      filename = re.findall("filename=(.+)", value)
+      return str(filename[0].strip('"'))
   return None
 
 def get_url_path_filename(url):

--- a/komand/helper.py
+++ b/komand/helper.py
@@ -138,7 +138,7 @@ def open_file(file_path):
   if os.path.isdir(dirname):
     if os.path.isfile(file_path):
       f = open(file_path, 'rb')
-      if type(f) is file:
+      if isinstance(f, IOBase) or isinstance(f, file):
         return f
       return None
     else:
@@ -295,7 +295,7 @@ def encode_file(file_path):
   '''Return a string of base64 encoded file provided as an absolute file path'''
   try:
     f = open_file(file_path)
-    if isinstance(f, file) or isinstance(f, IOBase):  # IOBase for Py3 compatibility
+    if isinstance(f, IOBase) or isinstance(f, file):  # IOBase for Py3 compatibility
       efile = base64.b64encode(f.read())
       return efile
     return None
@@ -303,7 +303,7 @@ def encode_file(file_path):
     logging.error('EncodeFile: Failed to open file: %s', e.strerror)
     raise Exception('EncodeFile')
   finally:
-    if isinstance(f, file) or isinstance(f, IOBase):
+    if isinstance(f, IOBase) or isinstance(f, file):
       f.close()
   return efile
 

--- a/komand/helper.py
+++ b/komand/helper.py
@@ -39,6 +39,7 @@ def clean_dict(dictionary):
 
   This function is designed so we only return useful data
   '''
+
   newdict = dict(dictionary)
   for key in dictionary.keys():
     if dictionary.get(key) is None:
@@ -86,6 +87,18 @@ def clean(object):
 
   return cleaned
 
+
+def get_hashes_string(s):
+  '''Return a dictionary of hashes for a string'''
+  s = s.encode("utf-8")
+  hashes={}
+  hashes['md5']    = hashlib.md5(s).hexdigest()
+  hashes['sha1']   = hashlib.sha1(s).hexdigest()
+  hashes['sha256'] = hashlib.sha256(s).hexdigest()
+  hashes['sha512'] = hashlib.sha512(s).hexdigest()
+  return hashes
+
+
 def check_hashes(src, checksum):
   '''Return boolean on whether a hash matches a file or string'''
   if type(src) is str:
@@ -100,14 +113,6 @@ def check_hashes(src, checksum):
   logging.info('CheckHashes: No checksum match')
   return False
 
-def get_hashes_string(s):
-  '''Return a dictionary of hashes for a string'''
-  hashes={}
-  hashes['md5']    = hashlib.md5(s).hexdigest()
-  hashes['sha1']   = hashlib.sha1(s).hexdigest()
-  hashes['sha256'] = hashlib.sha256(s).hexdigest()
-  hashes['sha512'] = hashlib.sha512(s).hexdigest()
-  return hashes
 
 def check_cachefile(cache_file):
   '''Return boolean on whether cachefile exists'''

--- a/komand/helper.py
+++ b/komand/helper.py
@@ -12,6 +12,7 @@ import time
 # Python 2/3 compatibility
 from six.moves.urllib import request
 from six.moves.urllib.error import HTTPError, URLError
+from io import IOBase
 
 
 def extract_value(begin, key, end, s):
@@ -294,7 +295,7 @@ def encode_file(file_path):
   '''Return a string of base64 encoded file provided as an absolute file path'''
   try:
     f = open_file(file_path)
-    if type(f) is file:
+    if isinstance(f, file) or isinstance(f, IOBase):  # IOBase for Py3 compatibility
       efile = base64.b64encode(f.read())
       return efile
     return None
@@ -302,7 +303,7 @@ def encode_file(file_path):
     logging.error('EncodeFile: Failed to open file: %s', e.strerror)
     raise Exception('EncodeFile')
   finally:
-    if type(f) is file:
+    if isinstance(f, file) or isinstance(f, IOBase):
       f.close()
   return efile
 

--- a/komand/helper.py
+++ b/komand/helper.py
@@ -286,7 +286,7 @@ def exec_command(command):
 def encode_string(s):
   '''Returns a base64 encoded string given a string'''
   if type(s) is str:
-    _bytes = base64.b64encode(s)
+    _bytes = base64.b64encode(s.encode())
     return _bytes
   return None
 

--- a/komand/helper.py
+++ b/komand/helper.py
@@ -7,8 +7,12 @@ import requests
 import ssl
 import subprocess
 import os
-import urllib.request
 import time
+
+# Python 2/3 compatibility
+from six.moves.urllib import request
+from six.moves.urllib.error import HTTPError, URLError
+
 
 def extract_value(begin, key, end, s):
   '''Returns a string from a given key/pattern using provided regexes
@@ -212,25 +216,25 @@ def open_url(url, timeout=None, verify=True, **kwargs):
   * verify  - Certificate validation as boolean
   * headers - Add many headers as Header_Name='Val', Header_Name2='Val2'
   '''
-  req = urllib.request.Request(url)
+  req = request.Request(url)
   if type(kwargs) is dict:
     for key in kwargs.keys():
       header = key.replace('_', '-')
       req.add_header(header, kwargs[key])
   try:
     if verify:
-      urlobj = urllib.request.urlopen(req, timeout=timeout)
+      urlobj = request.urlopen(req, timeout=timeout)
     else:
       ctx = ssl.create_default_context()
       ctx.check_hostname = False
       ctx.verify_mode = ssl.CERT_NONE
-      urlobj = urllib.request.urlopen(req, timeout=timeout, context=ctx)
+      urlobj = request.urlopen(req, timeout=timeout, context=ctx)
     return urlobj
-  except urllib.request.HTTPError as e:
+  except HTTPError as e:
     logging.error('HTTPError: %s for %s', str(e.code), url)
     if e.code == 304:
       return None
-  except urllib.request.URLError as e:
+  except URLError as e:
     logging.error('URLError: %s for %s', str(e.reason), url)
   raise Exception('GetURL Failed')
 
@@ -247,8 +251,8 @@ def check_url(url):
 
     '''Try Range request as secondary option'''
     hrange = {'Range':'bytes=0-2'}
-    req = urllib.request.Request(url,headers=hrange)
-    resp = urllib.request.urlopen(req)
+    req = request.Request(url,headers=hrange)
+    resp = request.urlopen(req)
     if resp.code >= 200 and resp.code <= 299:
       return True
 

--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,4 @@ setup(name='komand',
       packages=find_packages(),
       install_requires=['requests>=2.9','python_jsonschema_objects','jsonschema==2.3.0'],
       test_suite="tests.komand_test_suite",
-
       )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='komand',
       author_email='support@komand.com',
       url='http://komand.com',
       packages=find_packages(),
-      install_requires=['requests>=2.9','python_jsonschema_objects','jsonschema==2.3.0',],
+      install_requires=['requests>=2.9','python_jsonschema_objects','jsonschema==2.3.0'],
       test_suite="tests.komand_test_suite",
 
       )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,14 +3,15 @@ import tests.test_message
 import tests.test_action
 import tests.test_variables
 import tests.test_custom_encoder
-# import tests.test_helpers
+import tests.test_helpers
 
 def komand_test_suite():
     testmodules = [
         test_message,
         test_action,
         test_variables,
-        test_custom_encoder
+        test_custom_encoder,
+        test_helpers
         ]
 
     suite = unittest.TestSuite()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,6 +3,7 @@ import tests.test_message
 import tests.test_action
 import tests.test_variables
 import tests.test_custom_encoder
+import tests.test_helpers
 
 def komand_test_suite():
     testmodules = [
@@ -10,6 +11,7 @@ def komand_test_suite():
         test_action,
         test_variables,
         test_custom_encoder,
+        test_helpers
         ]
 
     suite = unittest.TestSuite()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,15 +3,14 @@ import tests.test_message
 import tests.test_action
 import tests.test_variables
 import tests.test_custom_encoder
-import tests.test_helpers
+# import tests.test_helpers
 
 def komand_test_suite():
     testmodules = [
         test_message,
         test_action,
         test_variables,
-        test_custom_encoder,
-        test_helpers
+        test_custom_encoder
         ]
 
     suite = unittest.TestSuite()

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,89 @@
+import unittest
+from komand import helper
+
+
+class TestHelpers(unittest.TestCase):
+
+    # extract_value
+
+    def test_extract_value_successful(self):
+        result = helper.extract_value(r'\s', 'Shell', r':\s(.*)\s', '\nShell: /bin/bash\n')
+        self.assertEqual("/bin/bash", result)
+
+    def test_extract_value_failure(self):
+        result = helper.extract_value(r'\s', 'Shell', r':\s(.*)\s', '\nShell: /bin/bash\n')
+        self.assertNotEqual("/bin/bas", result)
+
+    def test_extract_no_exceptions(self):
+        try:
+            helper.extract_value(r'\s', 'Shell', r':\s(.*)\s', '\nShell: /bin/bash\n')
+        except:
+            self.fail("Exception was thrown")
+
+    # clean_dict
+
+    def test_clean_dict_not_equal_successful(self):
+        sample = {"one": None, "two": "", "three": "woohoo"}
+        self.assertNotEqual(sample, helper.clean_dict({"one": None, "two": "", "three": "woohoo"}))
+
+    def test_clean_dict_equal_successful(self):
+        sample = {"three": "woohoo"}
+        self.assertDictEqual(sample, helper.clean_dict({"one": None, "two": "", "three": "woohoo"}))
+
+    def test_clean_dict_no_exceptions(self):
+        try:
+            helper.clean_dict({"test": "yay"})
+        except:
+            self.fail("Exception was thrown")
+
+    # clean_list
+
+    def test_clean_list_not_equal_successful(self):
+        sample = ["", None, "test"]
+        self.assertNotEqual(sample, helper.clean_list(["", None, "test"]))
+
+    def test_clean_list_equal_successful(self):
+        sample = ["test"]
+        self.assertEqual(sample, helper.clean_list(["", None, "test"]))
+
+    def test_clean_list_no_exceptions(self):
+        try:
+            helper.clean_list([])
+        except:
+            self.fail("Exception was thrown")
+
+    # clean
+
+    def test_clean_not_equal_list_successful(self):
+        sample = ["one", {"two": "", "three": None}, {"four": 4}, None]
+        self.assertNotEqual(sample, helper.clean(["one", {"two": "", "three": None}, {"four": 4}, None]))
+
+    def test_clean_equal_list_successful(self):
+        sample = ["one", {"two": "", "three": None}, {"four": 4}, None]
+        self.assertEqual(["one", {}, {"four": 4}], helper.clean(sample))
+
+    def test_clean_not_equal_dict_successful(self):
+        sample = {"one": [1, None, "", {"two": None}, {"three": 3}], "four": 4}
+        self.assertNotEqual(sample, helper.clean({"one": [1, None, "", {"two": None}, {"three": 3}], "four": 4}))
+
+    def test_clean_equal_dict_successful(self):
+        sample = {"one": [1, None, "", {"two": None}, {"three": 3}], "four": 4}
+        self.assertEqual({"one": [1, {}, {"three": 3}], "four": 4}, helper.clean(sample))
+
+    def test_clean_no_exceptions(self):
+        try:
+            helper.clean({"one": [1, None, "", {"two": None}, {"three": 3}], "four": 4})
+        except:
+            self.fail("Exception was thrown")
+
+    # get_hashes_string
+
+    def test_get_hashes_string(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertDictEqual(
+            {"md5": "c3fcd3d76192e4007dfb496cca67e13b",
+             "sha1": "32d10c7b8cf96570ca04ce37f2a19d84240d3a89",
+             "sha256": "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73",
+             "sha512": "4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f321389f77f48a879c7b1f1"},
+            helper.get_hashes_string(test_string)
+        )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,6 @@
 import unittest
 from komand import helper
+import requests
 
 
 class TestHelpers(unittest.TestCase):
@@ -149,3 +150,13 @@ class TestHelpers(unittest.TestCase):
         self.assertFalse(helper.check_hashes(test_string,
                                              "4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f32138asdfasdf"))
 
+    # open_url
+
+    # We can't reliably test known responses against dynamic responses from an endpoint we don't control,
+    # so this is the best we can do (to verify Python 2/3 compatibility
+    def test_open_url_no_exceptions(self):
+        try:
+            response = helper.open_url(url="https://api.ipify.org?format=json")
+            self.assertIsNotNone(response)
+        except:
+            self.fail("Exception caught")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -78,7 +78,7 @@ class TestHelpers(unittest.TestCase):
 
     # get_hashes_string
 
-    def test_get_hashes_string(self):
+    def test_get_hashes_string_equal_successful(self):
         test_string = "abcdefghijklmnopqrstuvwxyz"
         self.assertDictEqual(
             {"md5": "c3fcd3d76192e4007dfb496cca67e13b",
@@ -87,3 +87,64 @@ class TestHelpers(unittest.TestCase):
              "sha512": "4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f321389f77f48a879c7b1f1"},
             helper.get_hashes_string(test_string)
         )
+
+    def test_get_hashes_string_not_equal_successful(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertNotEqual(
+            {"sha1": "32d10c7b8cf96570ca04ce37f2a19d84240d3a89",
+             "sha256": "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73",
+             "sha512": "4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f321389f77f48a879c7b1f1"},
+            helper.get_hashes_string(test_string)
+        )
+
+    def test_get_hashes_string_no_exceptions(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        try:
+            helper.get_hashes_string(test_string)
+        except:
+            self.fail("Exception was thrown")
+
+    def test_get_hashes_string_all_keys_present(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        expected_keys = {"md5", "sha1", "sha256", "sha512"}
+
+        has_all_keys = expected_keys.issubset(helper.get_hashes_string(test_string))
+
+        self.assertTrue(has_all_keys)
+
+    # check_hashes
+
+    def test_check_hashes_true_md5_success(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertTrue(helper.check_hashes(test_string, "c3fcd3d76192e4007dfb496cca67e13b"))
+
+    def test_check_hashes_false_md5_failure(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertFalse(helper.check_hashes(test_string, "c3fcd3d76192asdfasdfasdf67e13z"))
+
+    def test_check_hashes_true_sha1_success(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertTrue(helper.check_hashes(test_string, "32d10c7b8cf96570ca04ce37f2a19d84240d3a89"))
+
+    def test_check_hashes_false_sha1_failure(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertFalse(helper.check_hashes(test_string, "32d10c7b8cf96570ca04ce37f2a19d84240d3aasdf"))
+
+    def test_check_hashes_true_sha256_success(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertTrue(helper.check_hashes(test_string, "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2daf18b73"))
+
+    def test_check_hashes_false_sha256_failure(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertFalse(helper.check_hashes(test_string, "71c480df93d6ae2f1efad1447c66c9525e316218cf51fc8d9ed832f2dafasdfasdf"))
+
+    def test_check_hashes_true_sha512_success(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertTrue(helper.check_hashes(test_string,
+                                            "4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f321389f77f48a879c7b1f1"))
+
+    def test_check_hashes_false_sha512_failure(self):
+        test_string = "abcdefghijklmnopqrstuvwxyz"
+        self.assertFalse(helper.check_hashes(test_string,
+                                             "4dbff86cc2ca1bae1e16468a05cb9881c97f1753bce3619034898faa1aabe429955a1bf8ec483d7421fe3c1646613a59ed5441fb0f32138asdfasdf"))
+

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -211,7 +211,7 @@ class TestHelpers(unittest.TestCase):
 
     # get_url_content_disposition
 
-    def test_get_url_content_disposition(self):
+    def test_get_url_content_disposition_success(self):
         headers = {"Content-Type": "text/html; charset=utf-8",
                     "Content-Disposition": "attachment; filename=test.html",
                     "Content-Length": 22
@@ -219,5 +219,23 @@ class TestHelpers(unittest.TestCase):
 
         self.assertEqual("test.html", helper.get_url_content_disposition(headers))
 
-    
+    # get_url_path_filename
+
+    def test_get_url_path_filename_success(self):
+        sample = "https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg"
+        expected = "googlechrome.dmg"
+
+        self.assertEqual(expected, helper.get_url_path_filename(sample))
+
+    def test_get_url_path_filename_success_with_two_periods(self):
+        sample = "https://dl.google.com/chrome/mac/stable/GGRO/google.chrome.dmg"
+        expected = "google.chrome.dmg"
+
+        self.assertEqual(expected, helper.get_url_path_filename(sample))
+
+    # get_url_filename
+
+    def test_get_url_filename_successful(self):
+        expected = "googlechrome.dmg"
+        self.assertEqual(expected, helper.get_url_filename("https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg"))
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,7 +1,7 @@
 import unittest
 from komand import helper
 import requests
-
+import os
 
 class TestHelpers(unittest.TestCase):
 
@@ -188,3 +188,15 @@ class TestHelpers(unittest.TestCase):
         encoded = helper.encode_string(sample)
 
         self.assertEqual(expected, encoded)
+
+    def test_encode_file_success(self):
+        expected = "a29tYW5kIGlzIGF3ZXNvbWU="
+
+        f = open("test.txt", "w+")
+        f.write("komand is awesome")
+        f.close()
+
+        actual = helper.encode_file("./test.txt")
+        self.assertEqual(expected, actual)
+
+        os.remove("test.txt")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -190,7 +190,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(expected, encoded)
 
     def test_encode_file_success(self):
-        expected = "a29tYW5kIGlzIGF3ZXNvbWU="
+        expected = b'a29tYW5kIGlzIGF3ZXNvbWU='
 
         f = open("test.txt", "w+")
         f.write("komand is awesome")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -160,3 +160,31 @@ class TestHelpers(unittest.TestCase):
             self.assertIsNotNone(response)
         except:
             self.fail("Exception caught")
+
+    # check_url
+
+    def test_check_url_success(self):
+        self.assertTrue(helper.check_url("https://google.com"))
+
+    def test_check_url_exception(self):
+        with self.assertRaises(requests.exceptions.InvalidURL):
+            helper.check_url("http:google.com")
+
+    # exec_command
+
+    def test_exec_command_success(self):
+        result = helper.exec_command("ls")
+        expected_keys = {"stdout", "rcode", "stderr"}
+        set_diff = expected_keys.difference(set(result))
+        has_keys = len(set_diff) == 0
+        self.assertTrue(has_keys)
+
+    # encode_string
+
+    def test_encode_string(self):
+        sample = "hello world"
+        expected = b'aGVsbG8gd29ybGQ='
+
+        encoded = helper.encode_string(sample)
+
+        self.assertEqual(expected, encoded)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -200,3 +200,24 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(expected, actual)
 
         os.remove("test.txt")
+
+    # check_url_modified
+
+    def test_check_url_modified_false(self):
+        self.assertFalse(helper.check_url_modified("https://httpstat.us/304"))
+
+    def test_check_url_modified_true(self):
+        self.assertTrue(helper.check_url_modified("https://httpstat.us/200"))
+
+    # get_url_content_disposition
+
+    def test_get_url_content_disposition(self):
+        headers = {"Content-Type": "text/html; charset=utf-8",
+                    "Content-Disposition": "attachment; filename=test.html",
+                    "Content-Length": 22
+        }
+
+        self.assertEqual("test.html", helper.get_url_content_disposition(headers))
+
+    
+

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -108,8 +108,8 @@ class TestHelpers(unittest.TestCase):
         test_string = "abcdefghijklmnopqrstuvwxyz"
         expected_keys = {"md5", "sha1", "sha256", "sha512"}
         
-        #TODO: Cleaner way to do this using set difference len((set1 - set2)) == 0
-        has_all_keys = expected_keys.issubset(helper.get_hashes_string(test_string))
+        hashes = set(helper.get_hashes_string(test_string))
+        has_all_keys = len(expected_keys.difference(hashes)) == 0
 
         self.assertTrue(has_all_keys)
 


### PR DESCRIPTION
Refactored helper library functions to make them compatible between Python 2 and 3. Also wrote  unit tests to cover all helper library functions outside of the cache file * functions. 