### PR TITLE
Monkey patches certifi.where() to load OS mounted CA path (KO-2744)

### DIFF
--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -20,8 +20,9 @@ CLI = komand.cli.CLI
 # dedicated CA bundle, which is exactly what we will do. In fact, the 
 # requests package even suggests to do exactly this: 
 # https://github.com/requests/requests/blob/master/requests/certs.py
+# http://docs.python-requests.org/en/master/user/advanced/#ca-certificates
 # So, we'll ask it to use SSL_CERT_FILE, one of the most common env vars
-# that would contain a path to SSL CA certificate directory.
+# that would contain a path to SSL CA certificate bundle.
 # We'll also set REQUESTS_CA_BUNDLE if it wasn't set already.
 import certifi
 import os

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -38,7 +38,7 @@ def where():
         else:
             return old_certifi_value
     except Exception as ex:
-        return 'Exception/old_certifi_value: ' + str(ex)
+        return old_certifi_value
 
 # and here's the monkey-patch itself.
 certifi.where = where

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -1,11 +1,12 @@
-__all__ = ['message', 'plugin', 'connection', 'trigger', 'action', 'variables', 'cli', 'helper']
-
 import komand.plugin
-
 import komand.action
-import komand.trigger 
+import komand.trigger
 import komand.connection
 import komand.cli
+import certifi
+import os
+
+__all__ = ['message', 'plugin', 'connection', 'trigger', 'action', 'variables', 'cli', 'helper']
 
 Plugin = komand.plugin.Plugin
 Action = komand.action.Action
@@ -24,9 +25,9 @@ CLI = komand.cli.CLI
 # So, we'll ask it to use SSL_CERT_FILE, one of the most common env vars
 # that would contain a path to SSL CA certificate bundle.
 # We'll also set REQUESTS_CA_BUNDLE if it wasn't set already.
-import certifi
-import os
+
 old_certifi_value = certifi.where()
+
 
 def where():
     try:

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -1,7 +1,6 @@
 __all__ = ['message', 'plugin', 'connection', 'trigger', 'action', 'variables', 'cli', 'helper']
 
 import komand.plugin
-
 import komand.action
 import komand.trigger 
 import komand.connection
@@ -14,3 +13,35 @@ Connection = komand.connection.Connection
 Input = komand.variables.Input
 Output = komand.variables.Output
 CLI = komand.cli.CLI
+
+# Many plugins use the certifi package, particularly indirectly through
+# the `requests` package. Certifi can be monkey-patched to not use the 
+# dedicated CA bundle, which is exactly what we will do. In fact, the 
+# `requests` package even suggests to do exactly this: 
+# https://github.com/requests/requests/blob/master/requests/certs.py
+# So, we'll ask it to use SSL_CERT_DIR, one of the most common env vars
+# that would contain a path to SSL CA certificate directory.
+# Additionally, we'll set the OpenSSL default path to look in the same
+# place as well. See OpenSSL.SSL.Context.set_default_verify_paths at:
+# https://pyopenssl.org/en/stable/api/ssl.html
+def monkey_patch_certifi_where():
+    import certifi
+    def where():
+        old_value = certifi.where()
+        try:
+            env_var = os.environ['SSL_CERT_DIR']
+            if !env_var && os.path.exists(env_var):
+                # tell SSL in general to use this path
+                SSLContext.load_verify_locations(pemfile=None, capath=env_var)
+                # and return callers of certifi.where() a shiny custom path
+                # to do their own verifications against the bundle.
+                return env_var
+        except Exception:
+            return old_value # if it failed, we just act all innocent-like.
+
+    # and here's the monkey-patch itself.
+    certifi.where = where
+    return
+
+# do the monkey business
+monkey_patch_certifi_where()

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -1,6 +1,7 @@
 __all__ = ['message', 'plugin', 'connection', 'trigger', 'action', 'variables', 'cli', 'helper']
 
 import komand.plugin
+
 import komand.action
 import komand.trigger 
 import komand.connection

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -16,11 +16,11 @@ Output = komand.variables.Output
 CLI = komand.cli.CLI
 
 # Many plugins use the certifi package, particularly indirectly through
-# the `requests` package. Certifi can be monkey-patched to not use the 
+# the requests package. Certifi can be monkey-patched to not use the 
 # dedicated CA bundle, which is exactly what we will do. In fact, the 
-# `requests` package even suggests to do exactly this: 
+# requests package even suggests to do exactly this: 
 # https://github.com/requests/requests/blob/master/requests/certs.py
-# So, we'll ask it to use SSL_CERT_DIR, one of the most common env vars
+# So, we'll ask it to use SSL_CERT_FILE, one of the most common env vars
 # that would contain a path to SSL CA certificate directory.
 # We'll also set REQUESTS_CA_BUNDLE if it wasn't set already.
 import certifi
@@ -29,7 +29,7 @@ old_certifi_value = certifi.where()
 
 def where():
     try:
-        env_var = os.environ['SSL_CERT_DIR']
+        env_var = os.environ['SSL_CERT_FILE']
         if len(env_var) > 0 and os.path.exists(env_var):
             # tell the requests package to use it too
             os.environ['REQUESTS_CA_BUNDLE'] = env_var

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -24,6 +24,7 @@ CLI = komand.cli.CLI
 # that would contain a path to SSL CA certificate directory.
 # We'll also set REQUESTS_CA_BUNDLE if it wasn't set already.
 import certifi
+import os
 old_certifi_value = certifi.where()
 
 def where():

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -22,9 +22,7 @@ CLI = komand.cli.CLI
 # https://github.com/requests/requests/blob/master/requests/certs.py
 # So, we'll ask it to use SSL_CERT_DIR, one of the most common env vars
 # that would contain a path to SSL CA certificate directory.
-# Additionally, we'll set the OpenSSL default path to look in the same
-# place as well. See OpenSSL.SSL.Context.set_default_verify_paths at:
-# https://pyopenssl.org/en/stable/api/ssl.html
+# We'll also set REQUESTS_CA_BUNDLE if it wasn't set already.
 import certifi
 old_certifi_value = certifi.where()
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='0.3.6',
+      version='0.3.7',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',


### PR DESCRIPTION
See code comments.

This depends on komand hotfix/0.30.1 - https://github.com/komand/komand/pull/1702