### PR TITLE
Move JSON Schemas out of Actions/Trigger/Connection

### DIFF
--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -6,11 +6,10 @@ import komand.action
 import komand.trigger 
 import komand.connection
 import komand.cli
+from komand.variables import Input, Output
 
 Plugin = komand.plugin.Plugin
 Action = komand.action.Action
 Trigger = komand.trigger.Trigger
 Connection = komand.connection.Connection
-Input = komand.variables.Input
-Output = komand.variables.Output
 CLI = komand.cli.CLI

--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -6,10 +6,11 @@ import komand.action
 import komand.trigger 
 import komand.connection
 import komand.cli
-from komand.variables import Input, Output
 
 Plugin = komand.plugin.Plugin
 Action = komand.action.Action
 Trigger = komand.trigger.Trigger
 Connection = komand.connection.Connection
 CLI = komand.cli.CLI
+Input = komand.variables.Input
+Output = komand.variables.Output

--- a/komand/connection.py
+++ b/komand/connection.py
@@ -1,3 +1,8 @@
+from jsonschema import validate
+import komand.util as util
+import komand.helper as helper
+
+
 class Connection(object):
     """Komand connection"""
 
@@ -8,3 +13,18 @@ class Connection(object):
     def connect(self, params={}):
         """ Connect """
         raise NotImplementedError
+
+    def set(self, parameters):
+        """ Set parameters """
+        self.parameters = parameters
+        self._validate()
+
+    def _validate(self):
+        """ Validate variables """
+        if self.schema:
+            validate(self.parameters, self.schema)
+
+    def sample(self):
+        """ Sample object """
+        if self.schema:
+            return util.sample(self.schema)

--- a/komand/connection.py
+++ b/komand/connection.py
@@ -6,7 +6,12 @@ import komand.helper as helper
 class Connection(object):
     """Komand connection"""
     def __init__(self, input):
-        self.schema = input.schema
+        # Maintain backwards compatibility here - if Input object passed in it will have a 'schema' property so use that
+        # Otherwise, the input is a JSON schema, so just use it directly
+        if hasattr(input, "schema"):
+            self.schema = input.schema
+        else:
+            self.schema = input
         self.parameters = {}
 
     def set(self, parameters):

--- a/komand/connection.py
+++ b/komand/connection.py
@@ -5,14 +5,9 @@ import komand.helper as helper
 
 class Connection(object):
     """Komand connection"""
-
     def __init__(self, input):
         self.schema = input.schema
         self.parameters = {}
-
-    def connect(self, params={}):
-        """ Connect """
-        raise NotImplementedError
 
     def set(self, parameters):
         """ Set parameters """
@@ -23,6 +18,10 @@ class Connection(object):
         """ Validate variables """
         if self.schema:
             validate(self.parameters, self.schema)
+
+    def connect(self, params={}):
+        """ Connect """
+        raise NotImplementedError
 
     def sample(self):
         """ Sample object """

--- a/komand/connection.py
+++ b/komand/connection.py
@@ -1,30 +1,10 @@
-from jsonschema import validate
-import komand.util as util
-import komand.helper as helper
-
 class Connection(object):
     """Komand connection"""
-    def __init__(self, schema={}):
-        self.schema = schema 
+
+    def __init__(self, input):
+        self.schema = input.schema
         self.parameters = {}
-
-    def set(self, parameters):
-        """ Set parameters """
-        self.parameters = parameters
-        self._validate()
-
-    def _validate(self):
-        """ Validate variables """
-        if self.schema:
-            validate(self.parameters, self.schema)
 
     def connect(self, params={}):
         """ Connect """
         raise NotImplementedError
-
-    def sample(self):
-        """ Sample object """
-        if self.schema:
-            return util.sample(self.schema)
-    
-

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='0.3.7',
+      version='0.3.8',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',


### PR DESCRIPTION
Just like the title says, this is an accompanying change to the overall plugin ecosystem to support removing separating the embedded JSON schemas from actions/triggers/connection.

Largest change here is the Connection initializer now taking an `input` object instead of a schema.

The import in `komand/__init__.py` had to be done to resolve import issues.