### PR TITLE
Python 3: Remove logging from certifi patch

### DIFF
--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -41,15 +41,13 @@ def where():
             # to do their own verifications against the bundle.
             return env_var
         else:
-            logging.warn('certifi.where(): Using old certifi value %s', old_certifi_value)
+            # old certifi value
             return old_certifi_value
     except Exception as ex:
-        logging.warn('certifi.where(): Using old certifi value %s', old_certifi_value)
+        # old certifi value
         return old_certifi_value
 
 
 # and here's the monkey-patch itself.
 certifi.where = where
-
-logging.info('certifi.where() monkey patched. It resolves to: %s', certifi.where())
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='0.3.12',
+      version='0.3.13',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',


### PR DESCRIPTION
Logging within the __init__.py in the certifi patching was breaking `logging.info` usage throughout plugins. This PR addresses that.