### PR TITLE
Python 2: Remove logging from certifi patch

### DIFF
--- a/komand/__init__.py
+++ b/komand/__init__.py
@@ -40,14 +40,12 @@ def where():
             # to do their own verifications against the bundle.
             return env_var
         else:
-            logging.warning('certifi.where(): Using old certifi value %s', old_certifi_value)
+            # old certifi value
             return old_certifi_value
     except Exception as ex:
-        logging.warning('certifi.where(): Using old certifi value %s', old_certifi_value)
+        # old certifi value
         return old_certifi_value
 
 
 # and here's the monkey-patch itself.
 certifi.where = where
-
-logging.info('certifi.where() monkey patched. It resolves to: %s', certifi.where())

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='komand',
-      version='0.2.22',
+      version='0.2.23',
       description='Komand Plugin SDK',
       author='Komand',
       author_email='support@komand.com',


### PR DESCRIPTION
Logging in __init__.py in the certifi patch broke `logging.info` usage throughout plugins. This PR addresses that.